### PR TITLE
Update xlocalize.js

### DIFF
--- a/bin/xlocalize.js
+++ b/bin/xlocalize.js
@@ -50,7 +50,7 @@ function mergeObjs() {
 function processFile(filename, dirJSON) {
     // Hacky, hacky RegExp parsing right now; replace with something better
     var fileContents = fs.readFileSync(filename, "utf8");
-    var translatables = fileContents.match(/translate\s*\([^\),]*/);
+    var translatables = fileContents.match(/translate\s*\([^\),]*/g);
     if(translatables) {
         /* jshint loopfunc: true */
         for(var i = 0; i < translatables.length; i++) {


### PR DESCRIPTION
Added the 'g' flag to the RegExp that matches 'translate'.
Before this the CLI was able to recognize only the first occurence of the 'translate' keyword. Instead, with the 'g' flags it finds all matches rather than stopping after the first match.